### PR TITLE
💄 add scroll to squads list in sidebar

### DIFF
--- a/packages/front/src/components/b-sidebar.vue
+++ b/packages/front/src/components/b-sidebar.vue
@@ -109,6 +109,12 @@ const toggleModal = () => { showModal.value = !showModal.value };
 .b-sidebar__squad-wrapper {
   display: grid;
   row-gap: var(--unit-0500);
+  overflow-y: scroll;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 
   .b-sidebar__squad {
     width: 100%;


### PR DESCRIPTION
Add a scroll to the squad list in the left sidebar. Closes #3. 
![scroll](https://user-images.githubusercontent.com/25932176/196829741-562ba20f-3c9b-4011-81ab-36580cb57665.gif)
